### PR TITLE
feat(utils): add utils for extracting UTM parameters and referrer domain

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -50,6 +50,8 @@ import {
     toParams,
 } from './utils'
 
+import { getUTMParameters } from './utils'
+
 describe('lib/utils', () => {
     describe('toParams', () => {
         it('handles unusual input', () => {
@@ -862,4 +864,158 @@ describe('lib/utils', () => {
         expect(shortTimeZone('Europe/Moscow')).toEqual('UTC+3')
         expect(shortTimeZone('Asia/Tokyo')).toEqual('UTC+9')
     })
+
+    describe('getUTMParameters', () => {
+        it('should return all UTM parameters when all are present in the URL', () => {
+            const url =
+                'https://example.com?utm_source=google&utm_medium=cpc&utm_campaign=summer_sale&utm_content=banner_ad&utm_term=running_shoes'
+            const expectedParams = {
+                source: 'google',
+                medium: 'cpc',
+                campaign: 'summer_sale',
+                content: 'banner_ad',
+                term: 'running_shoes',
+            }
+            expect(getUTMParameters(url)).toEqual(expectedParams)
+        })
+
+        it('should return an object with only the defined UTM parameters when given a URL containing a subset of the parameters', () => {
+            const url = 'https://example.com?utm_source=google&utm_medium=cpc'
+            const expectedParams = {
+                source: 'google',
+                medium: 'cpc',
+            }
+            expect(getUTMParameters(url)).toEqual(expectedParams)
+        })
+
+        it('should return all UTM parameters when given a query string', () => {
+            const queryString = '?utm_source=google&utm_medium=cpc&utm_campaign=summer_sale';
+            const expectedParams = {
+                source: 'google',
+                medium: 'cpc',
+                campaign: 'summer_sale',
+            };
+            expect(getUTMParameters(queryString)).toEqual(expectedParams);
+        });
+
+        it('should extract UTM parameters from window.location.search when no inputUrl is provided (browser environment)', () => {
+            const mockSearch =
+                '?utm_source=facebook&utm_medium=social&utm_campaign=new_product&utm_content=video_ad&utm_term=tech';
+
+            const locationSpy = jest.spyOn(window, 'location', 'get');
+            locationSpy.mockImplementation(() => ({ search: mockSearch } as any));
+
+            const expectedParams = {
+                source: 'facebook',
+                medium: 'social',
+                campaign: 'new_product',
+                content: 'video_ad',
+                term: 'tech',
+            };
+
+            expect(getUTMParameters()).toEqual(expectedParams);
+
+            locationSpy.mockRestore();
+        });
+
+        it('should correctly decode URL-encoded special characters in UTM parameter values', () => {
+            const url =
+                'https://example.com?utm_source=google%20source&utm_medium=cpc&utm_campaign=summer%26sale&utm_content=banner%2Bad&utm_term=running%25shoes';
+            const expectedParams = {
+                source: 'google source',
+                medium: 'cpc',
+                campaign: 'summer&sale',
+                content: 'banner+ad',
+                term: 'running%shoes',
+            };
+            expect(getUTMParameters(url)).toEqual(expectedParams);
+        });
+
+        it('should treat UTM parameters with only whitespace as undefined and not include them in the returned object', () => {
+            const url =
+                'https://example.com?utm_source=   &utm_medium= cpc &utm_campaign=summer_sale&utm_content=banner_ad&utm_term=running_shoes'
+            const expectedParams = {
+                medium: 'cpc',
+                campaign: 'summer_sale',
+                content: 'banner_ad',
+                term: 'running_shoes',
+            }
+            expect(getUTMParameters(url)).toEqual(expectedParams)
+        })
+    });
+})
+
+import { getReferrerDomain } from './utils'
+
+describe('getReferrerDomain', () => {
+    it('should return the external domain when referrer is from a different host', () => {
+        const currentHost = 'app.posthog.com'
+
+        // Test with a common search engine referrer
+        expect(getReferrerDomain('https://www.google.com/search?q=posthog', currentHost)).toEqual('www.google.com')
+
+        // Test with a social media referrer
+        expect(getReferrerDomain('https://t.co/', currentHost)).toEqual('t.co')
+
+        // Test with another external domain including a path
+        expect(getReferrerDomain('https://github.com/PostHog/posthog', currentHost)).toEqual('github.com')
+
+        // Test with a different protocol and a port number (port should be excluded from hostname)
+        expect(getReferrerDomain('http://anothersite.org:8080/path', currentHost)).toEqual('anothersite.org')
+
+        // Test with a subdomain
+        expect(getReferrerDomain('https://docs.another-company.co.uk', currentHost)).toEqual(
+            'docs.another-company.co.uk'
+        )
+    })
+
+    it('should return "direct" when the referrer is undefined or an empty string', () => {
+        const currentHost = 'app.posthog.com'
+        expect(getReferrerDomain(undefined, currentHost)).toEqual('direct')
+        expect(getReferrerDomain('', currentHost)).toEqual('direct')
+        expect(getReferrerDomain(undefined)).toEqual('direct')
+        expect(getReferrerDomain('')).toEqual('direct')
+    })
+
+    it('should return "internal" when the referrer host matches the current host', () => {
+        const currentHost = 'app.posthog.com'
+        const referrer = 'https://app.posthog.com/some/path'
+        expect(getReferrerDomain(referrer, currentHost)).toEqual('internal')
+    })
+
+    it('should return "direct" when document is undefined and no referrer parameter is provided', () => {
+        const originalDocument = global.document;
+        // Temporarily remove document
+        delete (global as any).document;
+
+        expect(getReferrerDomain()).toEqual('direct');
+
+        // Restore document
+        global.document = originalDocument;
+    });
+
+    it('should return "direct" when window is undefined and no currentHost is provided', () => {
+        const originalWindow = global.window
+        // @ts-expect-error - we are intentionally deleting window
+        delete global.window
+
+        expect(getReferrerDomain()).toEqual('direct')
+
+        global.window = originalWindow
+    })
+
+    // [Tusk] FAILING TEST
+    it('should return "direct" when the referrer is an invalid URL', () => {
+        const currentHost = 'app.posthog.com'
+        expect(getReferrerDomain('this is not a valid URL', currentHost)).toEqual('direct')
+        expect(getReferrerDomain(' ', currentHost)).toEqual('direct')
+        expect(getReferrerDomain('invalid', currentHost)).toEqual('direct')
+    })
+
+    // [Tusk] FAILING TEST
+    it('should handle relative URLs as referrers when window is undefined', () => {
+        const referrer = '/some/relative/path';
+        const currentHost = 'example.com'; // This should not be used since window is undefined
+        expect(getReferrerDomain(referrer, currentHost)).toEqual('direct');
+    });
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1866,3 +1866,58 @@ export function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
         timeout = setTimeout(() => func(...args), waitFor)
     }
 }
+
+/**
+ * Extract common UTM parameters from a URL (or current location by default).
+ * Returns only defined keys.
+ */
+export function getUTMParameters(
+    inputUrl?: string
+): { source?: string; medium?: string; campaign?: string; content?: string; term?: string } {
+    try {
+        let search = ''
+        if (!inputUrl) {
+            search = typeof window !== 'undefined' ? window.location.search : ''
+        } else if (inputUrl.startsWith('?')) {
+            search = inputUrl
+        } else {
+            const url = typeof window !== 'undefined' ? new URL(inputUrl, window.location.origin) : new URL(inputUrl)
+            search = url.search
+        }
+
+        const params = new URLSearchParams(search)
+        const result = {
+            source: ensureStringIsNotBlank(params.get('utm_source') || undefined) || undefined,
+            medium: ensureStringIsNotBlank(params.get('utm_medium') || undefined) || undefined,
+            campaign: ensureStringIsNotBlank(params.get('utm_campaign') || undefined) || undefined,
+            content: ensureStringIsNotBlank(params.get('utm_content') || undefined) || undefined,
+            term: ensureStringIsNotBlank(params.get('utm_term') || undefined) || undefined,
+        }
+        return objectClean(result)
+    } catch {
+        return {}
+    }
+}
+
+/**
+ * Classify and extract the referrer domain.
+ * - Returns 'direct' when no referrer.
+ * - Returns 'internal' when the referrer matches current host.
+ * - Otherwise returns the external referrer hostname (e.g. example.com).
+ */
+export function getReferrerDomain(referrer?: string, currentHost?: string): 'direct' | 'internal' | string {
+    const ref = referrer ?? (typeof document !== 'undefined' ? document.referrer : '')
+    if (!ref) {
+        return 'direct'
+    }
+    try {
+        const refUrl = new URL(ref, typeof window !== 'undefined' ? window.location.origin : undefined)
+        const host = currentHost ?? (typeof window !== 'undefined' ? window.location.host : undefined)
+        if (host && refUrl.host === host) {
+            return 'internal'
+        }
+        return refUrl.hostname
+    } catch {
+        return 'direct'
+    }
+}


### PR DESCRIPTION
## Problem
Product and growth workflows repeatedly need to extract UTM parameters and classify referrers for attribution. Without shared helpers, this logic is duplicated and inconsistent across the codebase.

## Changes
- Added `getUTMParameters(inputUrl?)`: Extracts `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term` from a URL or the current location. Returns only defined keys and is safe in non-browser contexts.
- Added `getReferrerDomain(referrer?, currentHost?)`: Returns `'direct'` if no referrer, `'internal'` if referrer matches the current host, or the external referrer hostname (e.g. `google.com`).
- No UI changes; no breaking changes.

## Does this work well for both Cloud and self-hosted?
Yes. These are frontend-only utilities with no backend or deployment differences.

## How did you test this code?
- [x] Tested with Tusk