### PR TITLE
feat: add timestamp validation for session recordings

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/process-event.ts
@@ -6,6 +6,22 @@ import { status } from '../../../utils/status'
 import { castTimestampOrNow } from '../../../utils/utils'
 import { activeMilliseconds } from './snapshot-segmenter'
 
+// Minimum valid timestamp: January 1, 2020 00:00:00 UTC
+// Session recordings couldn't exist before PostHog supported them
+const MIN_VALID_TIMESTAMP_MS = 1577836800000
+
+// Maximum valid timestamp: 24 hours in the future (to allow for clock skew)
+const MAX_FUTURE_TIMESTAMP_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Check if a timestamp is within a valid range for session recordings.
+ * Filters out clearly invalid values like timestamps of 1 (1970) or far-future dates.
+ */
+function isValidTimestamp(timestampMs: number): boolean {
+    const now = Date.now()
+    return timestampMs >= MIN_VALID_TIMESTAMP_MS && timestampMs <= now + MAX_FUTURE_TIMESTAMP_MS
+}
+
 function sanitizeForUTF8(input: string): string {
     // the JS console truncates some logs...
     // when it does that it doesn't check if the output is valid UTF-8


### PR DESCRIPTION
## Problem

In `src/main/ingestion-queues/session-recording/process-event.ts:209`, there's a TODO to filter out invalid timestamps like `1`:
```
// TODO we don't really want to support timestamps of 1,
//  but we don't currently filter out based on date of RRWebEvents being too far in the past
.filter((e) => (e?.timestamp || -1) > 0)
```

## Changes

Introduced a function to validate timestamps for session recordings, ensuring they fall within a defined range. This includes checks for minimum and maximum valid timestamps to filter out invalid values.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## How did you test this code?

- [ ] Tusk tests
